### PR TITLE
update deezer lists handling by using the 'next' property

### DIFF
--- a/ultrasonics/official_plugins/up_deezer.py
+++ b/ultrasonics/official_plugins/up_deezer.py
@@ -261,19 +261,15 @@ def run(settings_dict, **kwargs):
                 "index": 0
             }
 
-            playlists = self.api(url, params=params)["data"]
+            playlists_response = self.api(url, params=params)
+            playlists = playlists_response["data"]
 
-            playlist_count = len(playlists)
-            i = 1
+            playlists_count = playlists_response["total"]
 
-            # Get all playlists from the user
-            while playlist_count == limit:
-                params["index"] = limit * i
-
-                buffer = self.api(url, params=params)["data"]
-                playlists.extend(buffer)
-                playlist_count = len(buffer)
-                i += 1
+            # Get all playlists from the playlist
+            while "next" in playlists_response:
+                playlists_response = self.api(playlists_response["next"])
+                playlists.extend(playlists_response["data"])
 
             log.info(f"Found {len(playlists)} playlist(s) on Deezer.")
 
@@ -292,19 +288,15 @@ def run(settings_dict, **kwargs):
                 "index": 0
             }
 
-            tracks = self.api(url, params=params)["data"]
+            tracks_response = self.api(url, params=params)
+            tracks = tracks_response["data"]
 
-            tracks_count = len(tracks)
-            i = 1
+            tracks_count = tracks_response["total"]
 
             # Get all tracks from the playlist
-            while tracks_count == limit:
-                params["index"] = limit * i
-
-                buffer = self.api(url, params=params)["data"]
-                tracks.extend(buffer)
-                tracks_count = len(buffer)
-                i += 1
+            while "next" in tracks_response:
+                tracks_response = self.api(tracks_response["next"])
+                tracks.extend(tracks_response["data"])
 
             track_list = []
 


### PR DESCRIPTION
I had an issue where the Deezer API returned only 94 tracks from my playlist with over 400 tracks. After looking into it, it seems Deezer excluded some tracks from the first request, which expected 100 tracks to continue calling the API.

The Deezer API returns a "next" property containing the full URL to call to continue through the paging without having to handle indices, so I have updated the plugin to call that URL if the response contains it.