### PR TITLE
Remove duplicates before pushing new songs to Deezer

### DIFF
--- a/ultrasonics/official_plugins/up_deezer.py
+++ b/ultrasonics/official_plugins/up_deezer.py
@@ -33,7 +33,7 @@ handshake = {
     "mode": [
         "playlists"
     ],
-    "version": "0.3",
+    "version": "0.4",
     "settings": [
         {
             "type": "auth",
@@ -502,6 +502,9 @@ def run(settings_dict, **kwargs):
                 # Skip if no songs are to be removed
                 if remove_ids:
                     dz.remove_tracks_from_playlist(playlist_id, remove_ids)
+
+            # Remove duplicates from the list of new ids
+            new_ids = list(set(new_ids))
 
             # Add tracks to playlist in batches of 100
             url = f"https://api.deezer.com/playlist/{playlist_id}/tracks"


### PR DESCRIPTION
When updating a playlist on Deezer with a list of tracks IDs containing duplicates, the Deezer API returns the following error : 
`'This song already exists in this playlist', 'code': 500`.

The small change in this PR removes duplicate IDs from the list of tracks pushed to the Deezer API to prevent this error.