### PR TITLE
Fix for whole music import failing due to one JSON parse error in list

### DIFF
--- a/ultrasonics/official_plugins/up_local music database.py
+++ b/ultrasonics/official_plugins/up_local music database.py
@@ -180,19 +180,23 @@ class Database:
 
             for song in rows:
                 # Convert to songs_dict format
-                item = {
-                    "title": song[1],
-                    "artists": json.loads(song[2]),
-                    "album": song[3],
-                    "date": song[4],
-                    "isrc": song[5],
-                    "location": song[0]
-                }
+                try:
+                    item = {
+                        "title": song[1],
+                        "artists": json.loads(song[2]),
+                        "album": song[3],
+                        "date": song[4],
+                        "isrc": song[5],
+                        "location": song[0]
+                    }
 
-                # Remove any empty fields
-                item = {k: v for k, v in item.items() if v}
+                    # Remove any empty fields
+                    item = {k: v for k, v in item.items() if v}
 
-                found_songs.append(item)
+                    found_songs.append(item)
+                except TypeError:
+                    log.error("Error parsing JSON, skipping song:")
+                    log.error(song)
 
             return found_songs
 


### PR DESCRIPTION
Added a try/catch to catch an error when parsing JSON in up_local music database.py. 

I don't have the stacktrace on hand but the sync ran into issues where the JSON was not valid and then writing to local m3u playlist failed completely because the JSON could not be parsed. With this fix the sync continues running and skips one or more songs that failed to parse. It seems better than failing completely as it resulted in a fully synced playlist instead of nothing.

As a sidenote, the song that failed to parse was a .flac file, maybe coincidentally but it's interesting (most of my local files are MP3s and work fine)