### PR TITLE
docs: development operating model + wave board

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ in-repo docs are the source of truth for anything an agent needs to build correc
 | `adr/` | Architecture Decision Records — the immutable "why" | Cal, at decisions | Append-only; supersede, never edit |
 | `specs/` | One per feature — the contract; acceptance criteria = the test contract | `/grill-with-docs` | Frozen once implementation starts |
 | `proposals/` | Thorough design write-ups for work not yet decided/started | Agents / Cal | Living until accepted |
-| `plans/` | Order of work and current status (`roadmap.md`) | Agents | Living |
+| `plans/` | Order of work + current status: `roadmap.md` (what), `operating-model.md` (how), `wave-board.md` (live state) | Agents | Living |
 | `reference/` | Durable facts (e.g. the v1 architecture the port targets) | Agents | Updated as facts change |
 | `handoffs/` | Where an agent left off, so the next resumes cold | Agent at context end | One per boundary |
 | `sessions/` | Dated log of what happened and what's next | Agent at session end | Append-only |

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,13 @@ in-repo docs are the source of truth for anything an agent needs to build correc
 - **ADRs**: `NNNN-kebab-title.md`, header `# ADR-NNNN — Title`, then `Status:` / `Date:` and
   `Context` / `Decision` / `Consequences`. Number sequentially; a wrong decision is superseded by a
   new ADR that references it, never edited away.
+- **Status lines are grep-anchored.** Any doc with a status starts it with the exact token
+  `**Status:**` (bold *label*, plain value) as the first line after the title, so one regex spans
+  everything: `grep -rn '^\*\*Status:\*\*' docs/`. The label is the fixed anchor; the value varies.
+  Fixed vocabularies — **ADRs**: `Accepted` · `Complete` · `Superseded`. **Proposals**: `Draft` ·
+  `Research` · `Approved` · `Partially implemented` · `Implemented`.
+- **Every non-obvious rule or decision names the alternative it rejected** — one clause is enough
+  (ADRs, proposals, edit-site comments). Cheap to write; saves the "why not X?" archaeology later.
 - **Cross-reference by id** (`ADR-0004`, `CONTEXT.md`) so the graph stays navigable.
 - The rule from `AGENTS.md`: **no PR merges without its spec**, and non-obvious calls get an ADR.
 

--- a/docs/plans/operating-model.md
+++ b/docs/plans/operating-model.md
@@ -1,0 +1,131 @@
+# Development operating model
+
+How the revival is actually built: the factory manual. `roadmap.md` says *what* to build and in
+what order; this says *how* the work gets dispatched, kept honest, and kept visible. It is the last
+unbuilt piece of **Phase 0** — "build the factory, not the product".
+
+The model in one line: **human-gated waves of parallel work-cells, each cell a fixed
+skill-driven pipeline, all state on one board.** Cal opens each wave; agents run the cells; gates
+stop the slop; the board means nobody gets lost.
+
+---
+
+## 1. The work-cell — the atom of all work
+
+Every unit of work, from "port fuzzymatch" to "port the Deezer plugin", is a **cell**. A cell is
+one deliverable, one worktree, one PR, run through the **same** pipeline. Learn the cell once and a
+wave of ten is just the cell ten times.
+
+```
+(ambiguous?) → /research ──▶ docs/specs/<feature>.md ──▶ /grill-with-docs (freeze the spec)
+            ──▶ worktree ──▶ /tdd  or  /implement ──▶ /verify
+            ──▶ /code-review ──▶ /improve-codebase-architecture (anti-slop gate)
+            ──▶ draft PR ──▶ docs/handoffs/ + docs/sessions/
+```
+
+**Stage rules**
+
+- **/research** — run *only* when the spec would otherwise rest on a guess (an external API's real
+  behaviour, an ambiguous v1 detail). Its output is cited notes the spec can lean on. Skip when the
+  contract is already unambiguous.
+- **docs/specs/ entry** — the contract. Per AGENTS.md, **no PR merges without its spec**. If there
+  is no spec, the cell isn't ready; writing it is the first move, not code.
+- **/grill-with-docs** — freezes the spec by stress-testing its open questions. Mandatory for any
+  cell touching a checkpoint surface (§4); optional for a routine port against a frozen contract.
+- **/tdd vs /implement** — `/tdd` (red-green-refactor) is the default for anything with correctness
+  stakes: fuzzymatch, the runner, plugin I/O, auth. `/implement` is for scaffolding and wiring where
+  tests follow rather than lead. When in doubt, `/tdd`.
+- **/verify** — the cell must be shown *running*, not just green in tests. This is the roadmap's
+  literal exit-gate language ("a real Spotify playlist syncs to Plex through the UI").
+- **/code-review + /improve-codebase-architecture** — the two anti-slop gates. Review catches bugs;
+  the architecture pass catches the AI-generated sludge that passes tests but rots the codebase.
+  Both must pass. **Red is "don't ask for review"** (AGENTS.md quality gate).
+- **handoff + session log** — written when the cell closes *or* the agent runs low on context, so
+  the next agent resumes cold. Non-negotiable; it's what makes waves survivable.
+
+A cell is **done** when its PR is green on the full package suite, both anti-slop gates passed,
+`/verify` observed the behaviour, and its spec's acceptance criteria are ticked.
+
+## 2. Waves — how a phase becomes parallel work
+
+A **wave** is a batch of cells Cal dispatches together. Composing one:
+
+1. **Slice the phase into cells.** One deliverable each; independently reviewable; own worktree.
+2. **Draw the dependency edges.** Sequential only where correctness demands it (contracts before
+   the things that depend on them; the vertical slice before any fan-out). Everything else runs in
+   parallel.
+3. **Size to the rate-limit budget, not the dependency graph.** This is the real governor. A phase
+   can be embarrassingly parallel and still only run **N concurrent cells** — N set by the token /
+   rate ceiling, not by how many cells are theoretically independent. A wide phase drains as
+   several batches of N, not one giant fan-out. Undersized beats throttled-and-stalled.
+4. **Place the checkpoints.** Any cell touching a §4 surface stops for Cal *before* it merges.
+   Phase boundaries are always a checkpoint.
+
+Dispatch is **human-gated**: Cal opens each wave deliberately. This is a rate-limit decision as
+much as a control one — automated or scheduled fan-out would cheerfully blow the ceiling. Each cell
+runs as a background job in its own worktree and ends at a draft PR.
+
+## 3. The board — so nobody gets lost
+
+`docs/plans/wave-board.md` is the single source of truth for *live* state: the current wave, every
+cell and its status (`queued` / `in-flight` / `blocked` / `awaiting-Cal` / `merged`), what each is
+blocked on, and the next checkpoint. It is the index over the raw material in `handoffs/` and
+`sessions/` — those say *what happened*; the board says *where we are right now*.
+
+Rule: **a cell's status change updates the board in the same PR.** A board that lags is worse than
+no board. If you can't tell from the board what needs Cal, the wave has already lost cohesion.
+
+## 4. Checkpoint surfaces — when a cell stops for Cal
+
+Straight from AGENTS.md. A cell escalates rather than guesses when it touches:
+
+- the **auth layer** (`AuthProvider`, credential storage, OAuth flows),
+- the **plugin SDK contract** (the shape every plugin depends on),
+- the **database schema** or any migration,
+- **multi-tenancy / security** boundaries,
+- anything a spec left **genuinely ambiguous**.
+
+Everything else — a routine port with green CI and clean review — proceeds without a checkpoint.
+Phase boundaries are always a checkpoint.
+
+## 5. Skill → gate map
+
+Quality is a step that must pass, not a hope. Each skill is pinned to the gate it owns.
+
+| Gate | Skill | Fails the cell if… |
+|---|---|---|
+| Ambiguity resolved | `/research` | the spec would otherwise rest on a guess |
+| Contract frozen | `/grill-with-docs` | a checkpoint-surface spec still has open questions |
+| Correctness | `/tdd` | behaviour isn't pinned by tests written first |
+| It actually runs | `/verify` | the change was never exercised end-to-end |
+| No bugs | `/code-review` | review surfaces an unaddressed correctness issue |
+| No slop | `/improve-codebase-architecture` | the code passes tests but degrades the architecture |
+
+---
+
+## 6. First waves (Phase 0 → Phase 1 entry)
+
+Concrete application of the model to the roadmap's remaining Phase 0 work. Kept here as the worked
+example; live status lives on the board.
+
+**Wave 0.0 — external lead-time (Cal, non-agent, start immediately).** File the Spotify
+extended-quota and Apple Developer applications (ADR-0002 early parallel track). Real lead time;
+kick off before anything else so it's ticking in the background.
+
+**Wave 0.1 — the foundation cell (serialising; must land first).** Scaffold the Bun monorepo and CI
+per ADR-0001 — factory only, no product code. Everything downstream needs the `packages/*` skeleton
+and a green empty pipeline. One cell, `/implement`, no checkpoint beyond the phase gate.
+
+**Wave 0.2 — contracts + core (parallel behind 0.1, rate-limited to N cells).**
+- *SDK + AuthProvider freeze* — `/grill-with-docs` the `plugin-sdk-v2.md` open questions →
+  freeze both typed contracts. **Checkpoint (SDK contract + auth).** Blocks all plugin work.
+- *Song dict → Zod + tests* — `/tdd`. The sacred interchange type (ADR-0006).
+- *Fuzzymatch golden corpus* — generate the golden test corpus from a v1 checkout (ADR-0006), so
+  the port is pinned to v1 output before a line of it is written.
+
+**Phase 0 exit gate** (from roadmap): CI green on an empty pipeline · SDK + `AuthProvider` frozen ·
+song-dict Zod schema + tests merged · docs + ADRs in place. → opens **Phase 1**, the vertical slice.
+
+---
+
+*Owner: this doc is living (`plans/`). Amend as the factory teaches us where it creaks.*

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -14,7 +14,8 @@ SDK), 0005 (auth), 0006 (preserve song dict + fuzzymatch).
 
 Build the factory, not the product. Scaffold the Bun monorepo and CI. Freeze the plugin SDK
 (ADR-0004) and `AuthProvider` (ADR-0005) as typed contracts *before* any plugin. Port the song dict
-to Zod. Establish the docs system (this repo, done) and `AGENTS.md`.
+to Zod. Establish the docs system (this repo, done), `AGENTS.md`, and the **development operating
+model** (`operating-model.md` — the cell/wave/board machinery all later phases run on).
 
 **Exit gate:** CI green on an empty pipeline · SDK + `AuthProvider` interfaces frozen · song-dict
 Zod schema + its tests merged · docs skeleton and ADRs 0001–0006 in place.

--- a/docs/plans/wave-board.md
+++ b/docs/plans/wave-board.md
@@ -28,6 +28,17 @@ Checkpoint cells (§4 surfaces) are marked ⛔ — they stop for Cal before merg
 |---|---|---|---|
 | Scaffold Bun monorepo + CI (ADR-0001) | /implement | queued | everything downstream |
 
+**Acceptance criteria for the scaffold cell** (adopted from strategic-success's proven tooling):
+- **Read-only CI with `:check` variants** — `lint:check` / `format:check` / `type-check` run
+  read-only so CI *fails* rather than silently repairing (the mutating `bun run check` is local
+  only). Trigger on **both** PRs and direct pushes to `revival`.
+- **Import-cycle gate** — a `cycle-check` CI step, with a `cycle-check:update` rebaseline escape
+  hatch that must be justified in the commit message. Mechanical anti-slop guard on the dep graph.
+- **`.claude/settings.json`** — a scoped permission allowlist (`bun test`/`build`/`check`, `git`,
+  `gh`) to cut permission prompts during agent waves.
+- **Open call for the cell:** whether to adopt a module file-suffix taxonomy
+  (`*.interface.ts`/`*.config.ts`/`*.utils.ts`) — propose in the PR, don't impose silently.
+
 ### Wave 0.2 — contracts + core (parallel, behind 0.1; rate-limited) · **not dispatched**
 
 | Cell | Skill | Status | Notes |
@@ -47,3 +58,5 @@ in place. → opens **Phase 1 — vertical slice**.
 
 - **2026-08-03** — Board created alongside `operating-model.md`. Phase 0 waves seeded from roadmap;
   nothing dispatched yet. Awaiting Cal to open Wave 0.0 (external applications) and Wave 0.1.
+- **2026-08-03** — Folded strategic-success tooling conventions into Wave 0.1 acceptance criteria
+  (read-only `:check` CI, import-cycle gate, `.claude/settings.json` allowlist).

--- a/docs/plans/wave-board.md
+++ b/docs/plans/wave-board.md
@@ -1,0 +1,49 @@
+# Wave board
+
+Live state — the single source of truth for *where we are right now*. `operating-model.md` explains
+the mechanism; this is the running instance. `handoffs/`+`sessions/` say what happened; this says
+what's live and what needs Cal.
+
+**Rule:** a cell's status change updates this board in the same PR. A lagging board is worse than none.
+
+Status: `queued` · `in-flight` · `blocked` · `awaiting-Cal` · `merged`
+Checkpoint cells (§4 surfaces) are marked ⛔ — they stop for Cal before merge.
+
+---
+
+## Current phase: 0 — Foundations & operating model
+
+**Next checkpoint:** SDK + AuthProvider contract freeze (Wave 0.2), then the Phase 0 exit gate.
+
+### Wave 0.0 — external lead-time (Cal, non-agent) · **queued**
+
+| Cell | Owner | Status | Notes |
+|---|---|---|---|
+| Spotify extended-quota application | Cal | queued | ADR-0002 early track; real lead time — start ASAP |
+| Apple Developer application | Cal | queued | ADR-0002 early track |
+
+### Wave 0.1 — foundation (serialising) · **not dispatched**
+
+| Cell | Skill | Status | Blocks |
+|---|---|---|---|
+| Scaffold Bun monorepo + CI (ADR-0001) | /implement | queued | everything downstream |
+
+### Wave 0.2 — contracts + core (parallel, behind 0.1; rate-limited) · **not dispatched**
+
+| Cell | Skill | Status | Notes |
+|---|---|---|---|
+| ⛔ Freeze plugin SDK + AuthProvider contracts | /grill-with-docs | queued | blocks all plugin work; checkpoint |
+| Song dict → Zod + tests (ADR-0006) | /tdd | queued | the sacred interchange type |
+| Fuzzymatch golden corpus from v1 (ADR-0006) | /research → /tdd | queued | pin v1 output before porting |
+
+### Phase 0 exit gate
+
+CI green on empty pipeline · SDK + AuthProvider frozen · song-dict Zod + tests merged · docs + ADRs
+in place. → opens **Phase 1 — vertical slice**.
+
+---
+
+## Log
+
+- **2026-08-03** — Board created alongside `operating-model.md`. Phase 0 waves seeded from roadmap;
+  nothing dispatched yet. Awaiting Cal to open Wave 0.0 (external applications) and Wave 0.1.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,40 @@
+# proposals
+
+Thorough design write-ups for work that isn't decided or started yet — the place to grill a shape
+before it's built. Living documents: a proposal is refined in place, then either graduates to an ADR
+or is abandoned (kept, not deleted).
+
+## Conventions
+
+- **Filename:** `kebab-case-name.md`, **un-numbered** — *deliberately*, unlike ADRs. Proposals
+  mutate; numbering would invite renumbering churn and broken links. ADRs are numbered *because* they
+  record an immutable decision; proposals are named *because* they change. Cross-reference proposals
+  by relative path, ADRs by id.
+- **Status line first.** The first line after the title is `**Status:** <value> — optional clause.`,
+  the grep-anchored form from `../README.md`. Vocabulary: `Draft` · `Research` · `Approved` ·
+  `Partially implemented` · `Implemented`.
+- **Mutability:** edit the status in place; **never rename or move** a file when its status changes.
+  No `done/` or `in-progress/` subfolders — status changes constantly and refs are by path; this
+  index does the organising instead.
+- **Optional header lines** mirroring ADRs (`**Date:**`, `**Author:**`, `**Relates to:**`) are
+  incidental, not required.
+- Follow the house style from `../README.md`: **name the alternative you rejected**.
+
+## The graduation rule (proposal → ADR)
+
+When a proposal is **approved and building starts**, *and* the decision deserves a durable immutable
+record, write the ADR (next number). The proposal's status line then points at it
+(`**Status:** Implemented — see ADR-0007`). The proposal is **never deleted** — it stays as the
+working history of *how* the decision was reached, which the terse ADR deliberately omits. Not every
+proposal graduates; small ones can just reach `Implemented` without an ADR.
+
+## Index
+
+| Proposal | Status | Notes |
+|---|---|---|
+| `plugin-sdk-v2.md` | Draft | Fleshes ADR-0004 into a concrete surface. Checkpoint gate; freeze via `/grill-with-docs` before any plugin (Wave 0.2). |
+
+## Note on ambiguous cases
+
+None yet. When a doc doesn't fit cleanly (e.g. half-implemented, or a proposal that's really a
+reference doc), record the judgement call here rather than smoothing it over silently.

--- a/docs/proposals/plugin-sdk-v2.md
+++ b/docs/proposals/plugin-sdk-v2.md
@@ -1,6 +1,6 @@
 # Proposal: Plugin SDK v2
 
-Status: **Draft / not started** — captured for the Phase 0 SDK design pass.
+**Status:** Draft — captured for the Phase 0 SDK design pass.
 
 Fleshes out ADR-0004 (typed plugin SDK, explicit registration) into a concrete surface. This is the
 contract every plugin depends on, so it is a checkpoint gate (AGENTS.md) and must be agreed before


### PR DESCRIPTION
## What

Adds the **factory manual** for the agentic revival — the machinery all later phases run on. This is the last unbuilt piece of **Phase 0** ("build the factory, not the product").

- `docs/plans/operating-model.md` — the work-cell lifecycle (one fixed skill-driven pipeline per deliverable), rate-limit-sized human-gated waves, the skill→gate map, and the first Phase 0 waves worked out.
- `docs/plans/wave-board.md` — single source of truth for *live* state (which wave, which cells, what's blocked, what needs Cal), seeded with the remaining Phase 0 waves.
- README + roadmap wired to reference them.

## Why

The roadmap already says *what* to build; there was no written *how*. This closes that gap: quality skills (`/research`, `/tdd`, `/code-review`, `/improve-codebase-architecture`, `/verify`) become fixed pipeline stages that must pass, not ad-hoc choices — so parallel agent work stays high-quality and Cal stays oriented. Dispatch is human-gated and waves are sized to the rate-limit ceiling, per the meta-planning decision.

## Note on base

Targets `master` because `revival` isn't pushed. The diff therefore also contains the local `revival` seed commit (`bac3158`). Retarget to `revival` if you push it — this branch only adds the two new docs on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)