### PR TITLE
docs: fix operating-model inconsistencies found in review

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ in-repo docs are the source of truth for anything an agent needs to build correc
 |---|---|---|---|
 | `adr/` | Architecture Decision Records — the immutable "why" | Cal, at decisions | Append-only; supersede, never edit |
 | `specs/` | One per feature — the contract; acceptance criteria = the test contract | `/grill-with-docs` | Frozen once implementation starts |
-| `proposals/` | Thorough design write-ups for work not yet decided/started | Agents / Cal | Living until accepted |
+| `proposals/` | Thorough design write-ups for work not yet decided/started | Agents / Cal | Living; edited in place through to `Implemented`, never deleted |
 | `plans/` | Order of work + current status: `roadmap.md` (what), `operating-model.md` (how), `wave-board.md` (live state) | Agents | Living |
 | `reference/` | Durable facts (e.g. the v1 architecture the port targets) | Agents | Updated as facts change |
 | `handoffs/` | Where an agent left off, so the next resumes cold | Agent at context end | One per boundary |
@@ -19,14 +19,15 @@ in-repo docs are the source of truth for anything an agent needs to build correc
 ## Conventions
 
 - **British English**, concise, practical — these are internal working documents.
-- **ADRs**: `NNNN-kebab-title.md`, header `# ADR-NNNN — Title`, then `Status:` / `Date:` and
+- **ADRs**: `NNNN-kebab-title.md`, header `# ADR-NNNN — Title`, then `**Status:**` / `**Date:**` and
   `Context` / `Decision` / `Consequences`. Number sequentially; a wrong decision is superseded by a
   new ADR that references it, never edited away.
 - **Status lines are grep-anchored.** Any doc with a status starts it with the exact token
   `**Status:**` (bold *label*, plain value) as the first line after the title, so one regex spans
   everything: `grep -rn '^\*\*Status:\*\*' docs/`. The label is the fixed anchor; the value varies.
-  Fixed vocabularies — **ADRs**: `Accepted` · `Complete` · `Superseded`. **Proposals**: `Draft` ·
-  `Research` · `Approved` · `Partially implemented` · `Implemented`.
+  Fixed vocabularies — **ADRs**: `Proposed` (new, awaiting Cal) · `Accepted` · `Superseded`.
+  **Proposals**: `Draft` · `Research` · `Approved` · `Partially implemented` · `Implemented`.
+  **Plans**: free-form, but the line must be present so the survey sees living docs too.
 - **Every non-obvious rule or decision names the alternative it rejected** — one clause is enough
   (ADRs, proposals, edit-site comments). Cheap to write; saves the "why not X?" archaeology later.
 - **Cross-reference by id** (`ADR-0004`, `CONTEXT.md`) so the graph stays navigable.

--- a/docs/plans/operating-model.md
+++ b/docs/plans/operating-model.md
@@ -1,5 +1,7 @@
 # Development operating model
 
+**Status:** Living — the Phase 0 factory manual; amend as the factory teaches us where it creaks.
+
 How the revival is actually built: the factory manual. `roadmap.md` says *what* to build and in
 what order; this says *how* the work gets dispatched, kept honest, and kept visible. It is the last
 unbuilt piece of **Phase 0** — "build the factory, not the product".
@@ -31,7 +33,9 @@ wave of ten is just the cell ten times.
 - **docs/specs/ entry** — the contract. Per AGENTS.md, **no PR merges without its spec**. If there
   is no spec, the cell isn't ready; writing it is the first move, not code.
 - **/grill-with-docs** — freezes the spec by stress-testing its open questions. Mandatory for any
-  cell touching a checkpoint surface (§4); optional for a routine port against a frozen contract.
+  cell touching a checkpoint surface (§4). Skip it **only when a frozen spec already covers the
+  cell** (e.g. a routine plugin port against the frozen SDK contract + conformance test) — never
+  because the cell "seems simple". No spec, frozen or fresh, means no merge (AGENTS.md).
 - **/tdd vs /implement** — `/tdd` (red-green-refactor) is the default for anything with correctness
   stakes: fuzzymatch, the runner, plugin I/O, auth. `/implement` is for scaffolding and wiring where
   tests follow rather than lead. When in doubt, `/tdd`.
@@ -40,8 +44,8 @@ wave of ten is just the cell ten times.
 - **/code-review + /improve-codebase-architecture** — the two anti-slop gates. Review catches bugs;
   the architecture pass catches the AI-generated sludge that passes tests but rots the codebase.
   Both must pass. **Red is "don't ask for review"** (AGENTS.md quality gate).
-- **handoff + session log** — written when the cell closes *or* the agent runs low on context, so
-  the next agent resumes cold. Non-negotiable; it's what makes waves survivable.
+- **handoff + session log** — `/handoff`, written when the cell closes *or* the agent runs low on
+  context, so the next agent resumes cold. Non-negotiable; it's what makes waves survivable.
 
 A cell is **done** when its PR is green on the full package suite, both anti-slop gates passed,
 `/verify` observed the behaviour, and its spec's acceptance criteria are ticked.
@@ -58,6 +62,9 @@ A **wave** is a batch of cells Cal dispatches together. Composing one:
    can be embarrassingly parallel and still only run **N concurrent cells** — N set by the token /
    rate ceiling, not by how many cells are theoretically independent. A wide phase drains as
    several batches of N, not one giant fan-out. Undersized beats throttled-and-stalled.
+   **N is recorded on the board** (`wave-board.md`, "Concurrency budget") and is Cal's to tune —
+   never guessed per-wave. Starting value **N = 3**; raise it once a full wave has run without
+   hitting limits, lower it the first time one stalls.
 4. **Place the checkpoints.** Any cell touching a §4 surface stops for Cal *before* it merges.
    Phase boundaries are always a checkpoint.
 

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -18,7 +18,8 @@ to Zod. Establish the docs system (this repo, done), `AGENTS.md`, and the **deve
 model** (`operating-model.md` — the cell/wave/board machinery all later phases run on).
 
 **Exit gate:** CI green on an empty pipeline · SDK + `AuthProvider` interfaces frozen · song-dict
-Zod schema + its tests merged · docs skeleton and ADRs 0001–0006 in place.
+Zod schema + its tests merged · docs skeleton and ADRs 0001–0006 in place · operating model +
+wave board merged and the board reflecting live state.
 
 ## Phase 1 — Vertical slice (prove the whole pipe)
 **Status:** not started · **Owner mix:** agents build; Cal reviews the slice end-to-end

--- a/docs/plans/wave-board.md
+++ b/docs/plans/wave-board.md
@@ -1,13 +1,20 @@
 # Wave board
 
+**Status:** Live — Phase 0, nothing dispatched yet.
+
 Live state — the single source of truth for *where we are right now*. `operating-model.md` explains
 the mechanism; this is the running instance. `handoffs/`+`sessions/` say what happened; this says
 what's live and what needs Cal.
 
 **Rule:** a cell's status change updates this board in the same PR. A lagging board is worse than none.
 
-Status: `queued` · `in-flight` · `blocked` · `awaiting-Cal` · `merged`
-Checkpoint cells (§4 surfaces) are marked ⛔ — they stop for Cal before merge.
+**Concurrency budget: N = 3 concurrent cells.** The rate-limit governor from `operating-model.md`
+§2. Cal's to tune — raise after a clean full wave, lower the first time one stalls.
+
+**Cell status vocabulary:** `queued` · `in-flight` · `blocked` · `awaiting-Cal` · `merged`.
+Waves use the same words: a wave is `queued` until Cal opens it, then `in-flight`.
+Checkpoint cells — those touching a checkpoint surface (`operating-model.md` §4) — are marked ⛔
+and stop for Cal before merge.
 
 ---
 
@@ -22,7 +29,7 @@ Checkpoint cells (§4 surfaces) are marked ⛔ — they stop for Cal before merg
 | Spotify extended-quota application | Cal | queued | ADR-0002 early track; real lead time — start ASAP |
 | Apple Developer application | Cal | queued | ADR-0002 early track |
 
-### Wave 0.1 — foundation (serialising) · **not dispatched**
+### Wave 0.1 — foundation (serialising) · **queued**
 
 | Cell | Skill | Status | Blocks |
 |---|---|---|---|
@@ -39,7 +46,7 @@ Checkpoint cells (§4 surfaces) are marked ⛔ — they stop for Cal before merg
 - **Open call for the cell:** whether to adopt a module file-suffix taxonomy
   (`*.interface.ts`/`*.config.ts`/`*.utils.ts`) — propose in the PR, don't impose silently.
 
-### Wave 0.2 — contracts + core (parallel, behind 0.1; rate-limited) · **not dispatched**
+### Wave 0.2 — contracts + core (parallel, behind 0.1; max N cells) · **queued**
 
 | Cell | Skill | Status | Notes |
 |---|---|---|---|


### PR DESCRIPTION
Follow-up to #68. These fixes were committed ~20 minutes *after* #68 was merged, so they missed the squash — this lands them on `revival`.

Nine `/code-review` findings, all self-inflicted contradictions between the new conventions and the rules they encode:

- **ADR status vocabulary omitted `Proposed`** — AGENTS.md tells every new ADR to open at `Proposed`, so an agent obeying it would violate the convention on line one. `Complete` was unreachable; dropped. Now `Proposed`/`Accepted`/`Superseded`.
- **`/grill-with-docs` was "optional for a routine port"** — dead-ended against no-spec-no-merge. Now: skip only when a frozen spec already covers the cell.
- **`wave-board.md` and `operating-model.md` were invisible to the `**Status:**` grep anchor introduced in the same PR** — the single-source-of-truth-for-live-state doc was the one the status survey missed. Both now carry status lines.
- **Wave headings used `not dispatched`**, outside the board's own vocabulary. Normalised to `queued`.
- **`N`, "the real governor" of wave size, was never defined.** Now recorded on the board (`N = 3`, Cal's to tune) and referenced from §2.
- **Phase 0 exit gate** didn't mention the operating model the same hunk added to the phase body — the gate could go green with it absent.
- Unqualified `§4` cross-doc reference now names its target doc.
- ADR bullet still described the pre-anchor `Status:` header form.
- `proposals/` row said "living until accepted"; the lifecycle now runs through to `Implemented`.

Also pins the handoff stage to the `/handoff` skill, consistent with every other stage naming its tool.

**Rejected one finding:** `/verify` was flagged as non-existent, but it's a built-in skill (the check only looked at `~/.claude/skills/`). Verified before dismissing.

Verified: `grep -rn '^\*\*Status:\*\*' docs/` now spans all 16 status lines with none missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)